### PR TITLE
Add logging so we can see what the heck is going on with SFTP failures

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
@@ -83,6 +83,15 @@ public class SftpServicePublisher {
   @ServiceActivator(inputChannel = "sftpFailedProcess")
   public void sftpFailedProcess(GenericMessage message) {
     MessagingException payload = (MessagingException) message.getPayload();
+    log.error("SFTP FAILURE CAUSE stacktrace", payload.getCause());
+    log.error("SFTP FAILURE ROOT CAUSE stacktrace", payload.getRootCause());
+    if (payload.getCause() != null) {
+      log.error("SFTP FAILURE CAUSE message: {}", payload.getCause().getMessage());
+    }
+    if (payload.getCause() != null) {
+      log.error("SFTP FAILURE ROOT CAUSE message: {}", payload.getRootCause().getMessage());
+    }
+
     MessageHeaders headers = payload.getFailedMessage().getHeaders();
     String fileName = (String) headers.get(FileHeaders.REMOTE_FILE);
     int actionCount = Integer.valueOf((String) headers.get(ACTION_COUNT));

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
@@ -88,7 +88,7 @@ public class SftpServicePublisher {
     if (payload.getCause() != null) {
       log.error("SFTP FAILURE CAUSE message: {}", payload.getCause().getMessage());
     }
-    if (payload.getCause() != null) {
+    if (payload.getRootCause() != null) {
       log.error("SFTP FAILURE ROOT CAUSE message: {}", payload.getRootCause().getMessage());
     }
 


### PR DESCRIPTION
# Motivation and Context
We were getting SFTP failures but the logging was woeful, so we couldn't see what the problem(s) were.

# What has changed
Added loads of logging.

# How to test?
Misconfigure something to do with SFTP. Run the ATs.

# Links
Trello: https://trello.com/c/rIQYPDe8
